### PR TITLE
[EC-229] Add KeyVault instance for FIMS

### DIFF
--- a/infra/prod/_modules/key_vaults/certificates_lollipop.tf
+++ b/infra/prod/_modules/key_vaults/certificates_lollipop.tf
@@ -1,0 +1,35 @@
+resource "azurerm_key_vault_certificate" "lollipop_certificate_v1" {
+  name         = "lollipop-certificate-v1"
+  key_vault_id = module.key_vault.id
+
+  certificate_policy {
+    issuer_parameters {
+      name = "Self"
+    }
+
+    key_properties {
+      exportable = true
+      key_size   = 2048
+      key_type   = "RSA"
+      reuse_key  = false
+    }
+
+    secret_properties {
+      content_type = "application/x-pem-file"
+    }
+
+    x509_certificate_properties {
+      key_usage = [
+        "cRLSign",
+        "dataEncipherment",
+        "digitalSignature",
+        "keyAgreement",
+        "keyCertSign",
+        "keyEncipherment",
+      ]
+
+      subject            = "CN=${local.lollipop_jwt_host}"
+      validity_in_months = 1200
+    }
+  }
+}

--- a/infra/prod/_modules/key_vaults/data.tf
+++ b/infra/prod/_modules/key_vaults/data.tf
@@ -1,0 +1,27 @@
+data "azurerm_client_config" "current" {}
+
+data "azuread_group" "adgroup_admin" {
+  display_name = format("%s-adgroup-admin", var.project)
+}
+
+data "azuread_group" "adgroup_developers" {
+  display_name = format("%s-adgroup-developers", var.project)
+}
+
+data "azuread_group" "adgroup_externals" {
+  display_name = format("%s-adgroup-externals", var.project)
+}
+
+data "azuread_group" "adgroup_security" {
+  display_name = format("%s-adgroup-security", var.project)
+}
+
+data "azurerm_user_assigned_identity" "managed_identity_fims_ci" {
+  name                = "${var.product}-github-ci-identity"
+  resource_group_name = local.resource_group_name_identity
+}
+
+data "azurerm_user_assigned_identity" "managed_identity_fims_cd" {
+  name                = "${var.product}-github-cd-identity"
+  resource_group_name = local.resource_group_name_identity
+}

--- a/infra/prod/_modules/key_vaults/key_vault_fims.tf
+++ b/infra/prod/_modules/key_vaults/key_vault_fims.tf
@@ -1,0 +1,13 @@
+module "key_vault" {
+  source = "github.com/pagopa/terraform-azurerm-v3//key_vault?ref=v7.67.1"
+
+  name                       = "${var.product}-kv"
+  location                   = var.location
+  resource_group_name        = var.resource_group_name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "premium"
+  soft_delete_retention_days = 90
+  enable_rbac_authorization  = true
+
+  tags = var.tags
+}

--- a/infra/prod/_modules/key_vaults/locals.tf
+++ b/infra/prod/_modules/key_vaults/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  lollipop_jwt_host = "api.io.pagopa.it"
+
+  resource_group_name_identity = "${var.project}-identity-rg"
+}

--- a/infra/prod/_modules/key_vaults/main.tf
+++ b/infra/prod/_modules/key_vaults/main.tf
@@ -1,0 +1,8 @@
+terraform {
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}

--- a/infra/prod/_modules/key_vaults/outputs.tf
+++ b/infra/prod/_modules/key_vaults/outputs.tf
@@ -1,0 +1,7 @@
+output "key_vault_fims" {
+  value = {
+    id                  = module.key_vault.id
+    name                = module.key_vault.name
+    resource_group_name = module.key_vault.resource_group_name
+  }
+}

--- a/infra/prod/_modules/key_vaults/rbac_ad.tf
+++ b/infra/prod/_modules/key_vaults/rbac_ad.tf
@@ -1,0 +1,78 @@
+# resource "azurerm_key_vault_access_policy" "adgroup_admin" {
+#   key_vault_id = module.key_vault.id
+
+#   tenant_id = data.azurerm_client_config.current.tenant_id
+#   object_id = data.azuread_group.adgroup_admin.object_id
+
+#   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", "GetRotationPolicy", ]
+#   secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+#   storage_permissions     = []
+#   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+# }
+
+resource "azurerm_role_assignment" "adgroup_admin_secrets" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azuread_group.adgroup_admin.object_id
+}
+
+resource "azurerm_role_assignment" "adgroup_admin_keys" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Crypto Officer"
+  principal_id         = data.azuread_group.adgroup_admin.object_id
+}
+
+resource "azurerm_role_assignment" "adgroup_admin_certificates" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = data.azuread_group.adgroup_admin.object_id
+}
+
+## adgroup_developers group policy ##
+# resource "azurerm_key_vault_access_policy" "adgroup_developers" {
+#   key_vault_id = module.key_vault.id
+
+#   tenant_id = data.azurerm_client_config.current.tenant_id
+#   object_id = data.azuread_group.adgroup_developers.object_id
+
+#   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
+#   secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
+#   storage_permissions     = []
+#   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
+# }
+
+resource "azurerm_role_assignment" "adgroup_developers_secrets" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azuread_group.adgroup_developers.object_id
+}
+
+resource "azurerm_role_assignment" "adgroup_developers_keys" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Crypto Officer"
+  principal_id         = data.azuread_group.adgroup_developers.object_id
+}
+
+resource "azurerm_role_assignment" "adgroup_developers_certificates" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = data.azuread_group.adgroup_developers.object_id
+}
+
+resource "azurerm_role_assignment" "adgroup_externals_secrets" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azuread_group.adgroup_externals.object_id
+}
+
+resource "azurerm_role_assignment" "adgroup_externals_keys" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Crypto Officer"
+  principal_id         = data.azuread_group.adgroup_externals.object_id
+}
+
+resource "azurerm_role_assignment" "adgroup_externals_certificates" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = data.azuread_group.adgroup_externals.object_id
+}

--- a/infra/prod/_modules/key_vaults/rbac_ad.tf
+++ b/infra/prod/_modules/key_vaults/rbac_ad.tf
@@ -1,15 +1,3 @@
-# resource "azurerm_key_vault_access_policy" "adgroup_admin" {
-#   key_vault_id = module.key_vault.id
-
-#   tenant_id = data.azurerm_client_config.current.tenant_id
-#   object_id = data.azuread_group.adgroup_admin.object_id
-
-#   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", "GetRotationPolicy", ]
-#   secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
-#   storage_permissions     = []
-#   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
-# }
-
 resource "azurerm_role_assignment" "adgroup_admin_secrets" {
   scope                = module.key_vault.id
   role_definition_name = "Key Vault Secrets Officer"
@@ -27,19 +15,6 @@ resource "azurerm_role_assignment" "adgroup_admin_certificates" {
   role_definition_name = "Key Vault Certificates Officer"
   principal_id         = data.azuread_group.adgroup_admin.object_id
 }
-
-## adgroup_developers group policy ##
-# resource "azurerm_key_vault_access_policy" "adgroup_developers" {
-#   key_vault_id = module.key_vault.id
-
-#   tenant_id = data.azurerm_client_config.current.tenant_id
-#   object_id = data.azuread_group.adgroup_developers.object_id
-
-#   key_permissions         = ["Get", "List", "Update", "Create", "Import", "Delete", ]
-#   secret_permissions      = ["Get", "List", "Set", "Delete", "Restore", "Recover", ]
-#   storage_permissions     = []
-#   certificate_permissions = ["Get", "List", "Update", "Create", "Import", "Delete", "Restore", "Recover", ]
-# }
 
 resource "azurerm_role_assignment" "adgroup_developers_secrets" {
   scope                = module.key_vault.id

--- a/infra/prod/_modules/key_vaults/rbac_managed_identities.tf
+++ b/infra/prod/_modules/key_vaults/rbac_managed_identities.tf
@@ -1,0 +1,23 @@
+resource "azurerm_role_assignment" "identity_fims_ci_secrets" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = data.azurerm_user_assigned_identity.managed_identity_fims_ci.principal_id
+}
+
+resource "azurerm_role_assignment" "identity_fims_ci_certificates" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = data.azurerm_user_assigned_identity.managed_identity_fims_ci.principal_id
+}
+
+resource "azurerm_role_assignment" "identity_fims_cd_secrets" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = data.azurerm_user_assigned_identity.managed_identity_fims_cd.principal_id
+}
+
+resource "azurerm_role_assignment" "identity_fims_cd_certificates" {
+  scope                = module.key_vault.id
+  role_definition_name = "Key Vault Certificates Officer"
+  principal_id         = data.azurerm_user_assigned_identity.managed_identity_fims_cd.principal_id
+}

--- a/infra/prod/_modules/key_vaults/variables.tf
+++ b/infra/prod/_modules/key_vaults/variables.tf
@@ -1,0 +1,20 @@
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "tags" {
+  type = map(any)
+}
+
+variable "project" {
+  type = string
+}
+
+variable "product" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}

--- a/infra/prod/westeurope/.terraform.lock.hcl
+++ b/infra/prod/westeurope/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "2.47.0"
+  constraints = "<= 2.47.0"
+  hashes = [
+    "h1:KB9BNRNStbdsfdRmVXUwXtN77qgX5VjBy2UALcqp218=",
+    "h1:g8+gBFM4QVOEQFqAEs5pR6iXpbGvgPvcEi1evHwziyw=",
+    "h1:iRwDQBdXBpVBoYwM9au2RG01RQuJSm3TGQ2kioFVAas=",
+    "h1:zYMGokLn44KSWir7Nr4t8lEAPMB6JuXd2LlP2Ac2tMY=",
+    "zh:1372d81eb24ef3b4b00ea350fe87219f22da51691b8e42ce91d662f6c2a8af5e",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:1e654a74d171d6ff8f9f6f67e3ff1421d4c5e56a18607703626bf12cd23ba001",
+    "zh:35227fad617a0509c64ab5759a8b703b10d244877f1aa5416bfbcc100c96996f",
+    "zh:357f553f0d78d46a96c7b2ed06d25ee0fc60fc5be19812ccb5d969fa47d62e17",
+    "zh:58faa2940065137e3e87d02eba59ab5cd7137d7a18caf225e660d1788f274569",
+    "zh:7308eda0339620fa24f47cedd22221fc2c02cab9d5be1710c09a783aea84eb3a",
+    "zh:863eabf7f908a8263e28d8aa2ad1381affd6bb5c67755216781f674ef214100e",
+    "zh:8b95b595a7c14ed7b56194d03cdec253527e7a146c1c58961be09e6b5c50baee",
+    "zh:afbca6b4fac9a0a488bc22ff9e51a8f14e986137d25275068fd932f379a51d57",
+    "zh:c6aadec4c81a44c3ffc22c2d90ffc6706bf5a9a903a395d896477516f4be6cbb",
+    "zh:e54a59de7d4ef0f3a18f91fed0b54a2bce18257ae2ee1df8a88226e1023c5811",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.94.0"
   constraints = ">= 3.30.0, <= 3.94.0"

--- a/infra/prod/westeurope/README.md
+++ b/infra/prod/westeurope/README.md
@@ -4,6 +4,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | <= 2.47.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <= 3.94.0 |
 
 ## Providers
@@ -15,6 +16,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cosmos"></a> [cosmos](#module\_cosmos) | ../_modules/cosmos | n/a |
+| <a name="module_key_vaults"></a> [key\_vaults](#module\_key\_vaults) | ../_modules/key_vaults | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ../_modules/networking | n/a |
 | <a name="module_resource_groups"></a> [resource\_groups](#module\_resource\_groups) | ../_modules/resource_groups | n/a |
 

--- a/infra/prod/westeurope/key_vaults.tf
+++ b/infra/prod/westeurope/key_vaults.tf
@@ -1,0 +1,10 @@
+module "key_vaults" {
+  source = "../_modules/key_vaults"
+
+  resource_group_name = module.resource_groups.resource_group_fims.name
+  location            = module.resource_groups.resource_group_fims.location
+  project             = local.project
+  product             = local.product
+
+  tags = local.tags
+}

--- a/infra/prod/westeurope/main.tf
+++ b/infra/prod/westeurope/main.tf
@@ -12,6 +12,11 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "<= 3.94.0"
     }
+
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "<= 2.47.0"
+    }
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
Add a KeyVault dedicated to FIMS
KeyVault uses RBAC instead of vault access policies
Gives permissions to identities and ad groups

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

FIMS deserves its own KeyVault rather than share it with other streams

### Type of changes

- [X] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [ ] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [X] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [X] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
