### PR TITLE
[IIOCOM-1211] Add Config queue

### DIFF
--- a/infra/prod/_modules/storage_account/main.tf
+++ b/infra/prod/_modules/storage_account/main.tf
@@ -1,0 +1,8 @@
+terraform {
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}

--- a/infra/prod/_modules/storage_account/storage_account_fims.tf
+++ b/infra/prod/_modules/storage_account/storage_account_fims.tf
@@ -1,0 +1,16 @@
+module "storage_account_fims" {
+  source = "github.com/pagopa/terraform-azurerm-v3//storage_account?ref=v7.76.0"
+
+  name                          = "${var.prefix}${var.env_short}${var.domain}st"
+  domain                        = upper(var.domain)
+  account_kind                  = "StorageV2"
+  account_tier                  = "Standard"
+  access_tier                   = "Hot"
+  account_replication_type      = "ZRS"
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  advanced_threat_protection    = true
+  public_network_access_enabled = false
+
+  tags = var.tags
+}

--- a/infra/prod/_modules/storage_account/variables.tf
+++ b/infra/prod/_modules/storage_account/variables.tf
@@ -1,0 +1,30 @@
+variable "product" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "tags" {
+  type = map(any)
+}
+
+variable "prefix" {
+  type = string
+}
+
+variable "env_short" {
+  type        = string
+  description = "Short environment"
+}
+
+variable "domain" {
+  type        = string
+  description = "IO domain name"
+}

--- a/infra/prod/_modules/storage_queue/config_queue.tf
+++ b/infra/prod/_modules/storage_queue/config_queue.tf
@@ -1,0 +1,4 @@
+resource "azurerm_storage_queue" "config_queue" {
+  name                 = "config-queue"
+  storage_account_name = "${var.prefix}${var.env_short}${var.domain}st"
+}

--- a/infra/prod/_modules/storage_queue/variables.tf
+++ b/infra/prod/_modules/storage_queue/variables.tf
@@ -1,0 +1,13 @@
+variable "prefix" {
+  type = string
+}
+
+variable "env_short" {
+  type        = string
+  description = "Short environment"
+}
+
+variable "domain" {
+  type        = string
+  description = "IO domain name"
+}

--- a/infra/prod/westeurope/README.md
+++ b/infra/prod/westeurope/README.md
@@ -22,6 +22,8 @@ No providers.
 | <a name="module_key_vaults"></a> [key\_vaults](#module\_key\_vaults) | ../_modules/key_vaults | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ../_modules/networking | n/a |
 | <a name="module_resource_groups"></a> [resource\_groups](#module\_resource\_groups) | ../_modules/resource_groups | n/a |
+| <a name="module_storage_account"></a> [storage\_account](#module\_storage\_account) | ../_modules/storage_account | n/a |
+| <a name="module_storage_queue"></a> [storage\_queue](#module\_storage\_queue) | ../_modules/storage_queue | n/a |
 
 ## Resources
 

--- a/infra/prod/westeurope/storage_account.tf
+++ b/infra/prod/westeurope/storage_account.tf
@@ -1,0 +1,12 @@
+module "storage_account" {
+  source = "../_modules/storage_account"
+
+  prefix              = local.prefix
+  env_short           = local.env_short
+  domain              = local.domain
+  location            = module.resource_groups.resource_group_fims.location
+  product             = local.product
+  resource_group_name = module.resource_groups.resource_group_fims.name
+
+  tags = local.tags
+}

--- a/infra/prod/westeurope/storage_queue.tf
+++ b/infra/prod/westeurope/storage_queue.tf
@@ -1,0 +1,7 @@
+module "storage_queue" {
+  source = "../_modules/storage_queue"
+
+  prefix    = local.prefix
+  env_short = local.env_short
+  domain    = local.domain
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

* Add a storage account;
* Add a storage queue;

### Motivation and context

The `relying-party-func` needs a storage queue where to write the `OIDCClientCOnfig` so the provider can read them, 
we need a storage account in order to add a storage queue as well.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
