### PR TITLE
fix(infra): configure private endpoint for storage queue

### DIFF
--- a/infra/prod/_modules/networking/data.tf
+++ b/infra/prod/_modules/networking/data.tf
@@ -7,3 +7,14 @@ data "azurerm_virtual_network" "vnet_common" {
   name                = "${var.project}-vnet-common"
   resource_group_name = local.resource_group_name_common
 }
+
+data "azurerm_subnet" "private_endpoints_subnet" {
+  name                 = "pendpoints"
+  virtual_network_name = "${var.project}-vnet-common"
+  resource_group_name  = "${var.project}-rg-common"
+}
+
+data "azurerm_private_dns_zone" "privatelink_queue_core_windows_net" {
+  name                = "privatelink.queue.core.windows.net"
+  resource_group_name = "${var.project}-rg-common"
+}

--- a/infra/prod/_modules/networking/outputs.tf
+++ b/infra/prod/_modules/networking/outputs.tf
@@ -4,3 +4,16 @@ output "subnet_fims" {
     name = module.fims_snet.name
   }
 }
+
+output "subnet_private_endpoints" {
+  value = {
+    id   = data.azurerm_subnet.private_endpoints_subnet.id
+    name = data.azurerm_subnet.private_endpoints_subnet.name
+  }
+}
+
+output "dns_zone_privatelink_queue_core_windows_net" {
+  value = {
+    id = data.azurerm_private_dns_zone.privatelink_queue_core_windows_net.id
+  }
+}

--- a/infra/prod/_modules/storage/storage_account_fims.tf
+++ b/infra/prod/_modules/storage/storage_account_fims.tf
@@ -14,22 +14,11 @@ module "storage_account_fims" {
   tags = var.tags
 }
 
-data "azurerm_subnet" "private_endpoints_subnet" {
-  name                 = "pendpoints"
-  virtual_network_name = format("%s-vnet-common", var.product)
-  resource_group_name  = format("%s-rg-common", var.product)
-}
-
-data "azurerm_private_dns_zone" "privatelink_queue_core_windows_net" {
-  name                = "privatelink.queue.core.windows.net"
-  resource_group_name = format("%s-rg-common", var.product)
-}
-
 resource "azurerm_private_endpoint" "queue" {
   name                = format("%s-queue-endpoint", module.storage_account_fims.name)
   location            = var.location
   resource_group_name = var.resource_group_name
-  subnet_id           = data.azurerm_subnet.private_endpoints_subnet.id
+  subnet_id           = var.private_endpoints_subnet_id
 
   private_service_connection {
     name                           = format("%s-queue", module.storage_account_fims.name)
@@ -40,7 +29,7 @@ resource "azurerm_private_endpoint" "queue" {
 
   private_dns_zone_group {
     name                 = "private-dns-zone-group"
-    private_dns_zone_ids = [data.azurerm_private_dns_zone.privatelink_queue_core_windows_net.id]
+    private_dns_zone_ids = [var.private_dns_zones.privatelink_queue_core_windows_net.id]
   }
 
   tags = var.tags

--- a/infra/prod/_modules/storage/storage_account_fims.tf
+++ b/infra/prod/_modules/storage/storage_account_fims.tf
@@ -13,3 +13,35 @@ module "storage_account_fims" {
 
   tags = var.tags
 }
+
+data "azurerm_subnet" "private_endpoints_subnet" {
+  name                 = "pendpoints"
+  virtual_network_name = format("%s-vnet-common", var.product)
+  resource_group_name  = format("%s-rg-common", var.product)
+}
+
+data "azurerm_private_dns_zone" "privatelink_queue_core_windows_net" {
+  name                = "privatelink.queue.core.windows.net"
+  resource_group_name = format("%s-rg-common", var.product)
+}
+
+resource "azurerm_private_endpoint" "queue" {
+  name                = format("%s-queue-endpoint", module.storage_account_fims.name)
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = data.azurerm_subnet.private_endpoints_subnet.id
+
+  private_service_connection {
+    name                           = format("%s-queue", module.storage_account_fims.name)
+    private_connection_resource_id = module.storage_account_fims.id
+    is_manual_connection           = false
+    subresource_names              = ["queue"]
+  }
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group"
+    private_dns_zone_ids = [data.azurerm_private_dns_zone.privatelink_queue_core_windows_net.id]
+  }
+
+  tags = var.tags
+}

--- a/infra/prod/_modules/storage/storage_account_fims.tf
+++ b/infra/prod/_modules/storage/storage_account_fims.tf
@@ -9,7 +9,7 @@ module "storage_account_fims" {
   resource_group_name           = var.resource_group_name
   location                      = var.location
   advanced_threat_protection    = true
-  public_network_access_enabled = false
+  public_network_access_enabled = true
 
   tags = var.tags
 }

--- a/infra/prod/_modules/storage/variables.tf
+++ b/infra/prod/_modules/storage/variables.tf
@@ -14,3 +14,15 @@ variable "location" {
 variable "tags" {
   type = map(any)
 }
+
+variable "private_endpoints_subnet_id" {
+  type = string
+}
+
+variable "private_dns_zones" {
+  type = object({
+    privatelink_queue_core_windows_net = object({
+      id = string
+    })
+  })
+}

--- a/infra/prod/westeurope/storage.tf
+++ b/infra/prod/westeurope/storage.tf
@@ -5,5 +5,13 @@ module "storage" {
   product             = local.product
   resource_group_name = module.resource_groups.resource_group_fims.name
 
+  private_endpoints_subnet_id = module.networking.subnet_private_endpoints.id
+
+  private_dns_zones = {
+    privatelink_queue_core_windows_net = {
+      id = module.networking.dns_zone_privatelink_queue_core_windows_net.id
+    }
+  }
+
   tags = local.tags
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. add `azurerm_private_endpoint.queue` resource
2. (tempfix) set `azurerm_storage_account. public_network_access_enabled` as `true` (it's empty! don't worry, I'll revert with the next PR)

<!--- Describe your changes in detail -->

### Motivation and context
1. without this `azurerm_private_endpoint` terraform can't access to storage queues and consequently can't perform `tf apply` on this kind of resources

2. we temporally enabled `public_network_access_enabled` in order to apply this changes, since the GitHub hosted runner does not have access to our internal vnet

fixes that failed run: https://github.com/pagopa/io-fims/actions/runs/8687833259

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
