### PR TITLE
refactor: Replace cosmos connection string with default credentials

### DIFF
--- a/apps/openid-provider-app/.env.example
+++ b/apps/openid-provider-app/.env.example
@@ -10,6 +10,6 @@ ISSUER="http://localhost:3001"
 COOKIES_KEY="just-for-testing-purposes"
 ENABLE_FEATURE_REMEMBER_GRANT="true"
 ENABLE_PROXY=false
-COSMOSDB_CONNECTION_STRING="a connection string"
+COSMOSDB_URI="a valid uri"
 COSMOSDB_NAME="a cosmosdb name"
 JWK_PRIMARY=

--- a/apps/openid-provider-app/package.json
+++ b/apps/openid-provider-app/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@azure/cosmos": "^4.0.0",
     "@azure/functions": "^3.2.0",
+    "@azure/identity": "^4.1.0",
     "@pagopa/io-functions-commons": "^29.0.0",
     "@pagopa/ts-commons": "^10.2.1",
     "applicationinsights": "1.8.10",

--- a/apps/openid-provider-app/src/__tests__/data.ts
+++ b/apps/openid-provider-app/src/__tests__/data.ts
@@ -9,7 +9,7 @@ const jwk = jose2.JWK.generateSync("EC", "P-256", { use: "sig" }).toJWK(true);
 export const envs: NodeJS.ProcessEnv = {
   IO_BACKEND_BASE_URL: "https://app-backend.io.italia.it",
   COSMOSDB_NAME: "fims",
-  COSMOSDB_CONNECTION_STRING:
+  COSMOSDB_URI:
     "AccountEndpoint=https://unit-test-account.documents.azure.com:443/;AccountKey=key;",
   ENABLE_FEATURE_REMEMBER_GRANT: "true",
   APPLICATION_NAME: "io-openid-provider.test",
@@ -30,14 +30,14 @@ export const config: Config = {
     baseURL: new URL(envs["IO_BACKEND_BASE_URL"] as string),
   },
   cosmosdb: {
-    cosmosDbName: envs["COSMOSDB_NAME"],
-    connectionString: envs["COSMOSDB_CONNECTION_STRING"],
+    cosmosDbName: envs["COSMOSDB_NAME"]!,
+    endpoint: envs["COSMOSDB_URI"]!,
   },
   features: {
     grant: {
       enableRememberGrantFeature:
         envs["ENABLE_FEATURE_REMEMBER_GRANT"] === "true",
-      grantTTL: parseInt(envs["GRANT_TTL_IN_SECONDS"]) as Seconds,
+      grantTTL: parseInt(envs["GRANT_TTL_IN_SECONDS"]!) as Seconds,
     },
   },
   info: {

--- a/apps/openid-provider-app/src/adapters/cosmosdb/client.ts
+++ b/apps/openid-provider-app/src/adapters/cosmosdb/client.ts
@@ -8,6 +8,7 @@ import { pipe } from "fp-ts/lib/function.js";
 import { Logger } from "../../domain/logger/index.js";
 import { show } from "../../domain/utils.js";
 import { CosmosDBConfig } from "./types.js";
+import { DefaultAzureCredential } from "@azure/identity";
 
 /**
  * Create and check the connection to the database
@@ -16,7 +17,7 @@ export const makeCosmosDbClient = (
   config: CosmosDBConfig,
   logger: Logger,
 ): TE.TaskEither<string, Database> => {
-  const cosmosdbClient = new CosmosClient(config.connectionString);
+  const cosmosdbClient = new CosmosClient({ aadCredentials: new DefaultAzureCredential(), endpoint: config.endpoint });
   const instance = cosmosdbClient.database(config.cosmosDbName);
   return pipe(
     E.tryCatch(() => {

--- a/apps/openid-provider-app/src/adapters/cosmosdb/types.ts
+++ b/apps/openid-provider-app/src/adapters/cosmosdb/types.ts
@@ -1,4 +1,4 @@
 export interface CosmosDBConfig {
-  readonly connectionString: string;
+  readonly endpoint: string;
   readonly cosmosDbName: string;
 }

--- a/apps/openid-provider-app/src/config.ts
+++ b/apps/openid-provider-app/src/config.ts
@@ -33,7 +33,7 @@ const EnvType = t.type({
   APPLICATION_NAME: NonEmptyString,
   AUTHENTICATION_COOKIE_KEY: NonEmptyString,
   COOKIES_KEY: t.string,
-  COSMOSDB_CONNECTION_STRING: NonEmptyString,
+  COSMOSDB_URI: NonEmptyString,
   COSMOSDB_NAME: NonEmptyString,
   ENABLE_FEATURE_REMEMBER_GRANT: tt.fromNullable(tt.BooleanFromString, false),
   ENABLE_PROXY: tt.fromNullable(tt.BooleanFromString, false),
@@ -63,7 +63,7 @@ const makeConfig = (envs: EnvType): Config => ({
     baseURL: new URL(envs.IO_BACKEND_BASE_URL.href),
   },
   cosmosdb: {
-    connectionString: envs.COSMOSDB_CONNECTION_STRING,
+    endpoint: envs.COSMOSDB_URI,
     cosmosDbName: envs.COSMOSDB_NAME,
   },
   features: {

--- a/apps/rp-func/local.settings.json.example
+++ b/apps/rp-func/local.settings.json.example
@@ -3,7 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
-    "COSMOS_DB_CONNECTION_STRING": "",
+    "COSMOS_DB_URI": "",
     "COSMOS_DB_NAME": "fims"
   }
 }

--- a/apps/rp-func/package.json
+++ b/apps/rp-func/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@azure/cosmos": "^4.0.0",
     "@azure/functions": "^4.3.0",
+    "@azure/identity": "^4.1.0",
     "@pagopa/handler-kit": "^1.1.0",
     "@pagopa/handler-kit-azure-func": "^2.0.3",
     "@pagopa/logger": "^1.0.1",

--- a/apps/rp-func/src/infra/config.ts
+++ b/apps/rp-func/src/infra/config.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const configSchema = z.object({
   cosmos: z.object({
-    connectionString: z.string().min(1),
+    endpoint: z.string().url(),
     databaseName: z.string().default("rp"),
   }),
 });

--- a/apps/rp-func/src/infra/main.ts
+++ b/apps/rp-func/src/infra/main.ts
@@ -10,15 +10,16 @@ import { createOIDCClientConfigHandler } from "./handlers/create-oidc-client-con
 import { CosmosOIDCClientConfigRepository } from "./cosmosdb/oidc-client-config.js";
 
 import { configSchema } from "./config.js";
+import { DefaultAzureCredential } from "@azure/identity";
 
 const config = configSchema.parse({
   cosmos: {
-    connectionString: process.env.COSMOS_DB_CONNECTION_STRING,
+    endpoint: process.env.COSMOS_DB_URI,
     databaseName: process.env.COSMOS_DB_NAME,
   },
 });
 
-const cosmosClient = new CosmosClient(config.cosmos.connectionString);
+const cosmosClient = new CosmosClient({ aadCredentials: new DefaultAzureCredential(), endpoint: config.cosmos.endpoint });
 
 const database = cosmosClient.database(config.cosmos.databaseName);
 

--- a/infra/resources/prod/_modules/cosmos/outputs.tf
+++ b/infra/resources/prod/_modules/cosmos/outputs.tf
@@ -20,8 +20,3 @@ output "cosmos_account_fims_primary_key" {
   value     = module.cosmosdb_account_fims.primary_key
   sensitive = true
 }
-
-output "cosmos_account_fims_primary_connection_string" {
-  value     = module.cosmosdb_account_fims.connection_strings[0]
-  sensitive = true
-}

--- a/infra/resources/prod/_modules/custom_roles/cosmos_query.tf
+++ b/infra/resources/prod/_modules/custom_roles/cosmos_query.tf
@@ -1,0 +1,13 @@
+resource "azurerm_role_definition" "cosmos_query" {
+  name        = "cosmos-query"
+  scope       = var.resource_group_id
+  description = "A role to make query on cosmos"
+
+  permissions {
+    actions = ["Microsoft.DocumentDB/databaseAccounts/readMetadata", "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/*"]
+  }
+
+  assignable_scopes = [
+    var.resource_group_id
+  ]
+}

--- a/infra/resources/prod/_modules/custom_roles/main.tf
+++ b/infra/resources/prod/_modules/custom_roles/main.tf
@@ -1,0 +1,8 @@
+terraform {
+
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+  }
+}

--- a/infra/resources/prod/_modules/custom_roles/variables.tf
+++ b/infra/resources/prod/_modules/custom_roles/variables.tf
@@ -1,0 +1,3 @@
+variable "resource_group_id" {
+  type = string
+}

--- a/infra/resources/prod/_modules/web_apps/locals.tf
+++ b/infra/resources/prod/_modules/web_apps/locals.tf
@@ -38,7 +38,6 @@ locals {
       COSMOSDB_NAME                   = "fims"
       COSMOSDB_URI                    = var.cosmos_db.endpoint
       COSMOSDB_KEY                    = var.cosmos_db.primary_key
-      COSMOSDB_CONNECTION_STRING      = format("AccountEndpoint=%s;AccountKey=%s;", var.cosmos_db.endpoint, var.cosmos_db.primary_key)
       AUTHENTICATION_COOKIE_KEY       = "X-IO-FIMS-Token"
       GRANT_TTL_IN_SECONDS            = "86400"
       ISSUER                          = "https://io-p-fims-oidc-provider-app.azurewebsites.net"

--- a/infra/resources/prod/westeurope/README.md
+++ b/infra/resources/prod/westeurope/README.md
@@ -17,6 +17,7 @@ No providers.
 |------|--------|---------|
 | <a name="module_apim"></a> [apim](#module\_apim) | ../_modules/apim | n/a |
 | <a name="module_cosmos"></a> [cosmos](#module\_cosmos) | ../_modules/cosmos | n/a |
+| <a name="module_custom_roles"></a> [custom\_roles](#module\_custom\_roles) | ../_modules/custom_roles/ | n/a |
 | <a name="module_key_vaults"></a> [key\_vaults](#module\_key\_vaults) | ../_modules/key_vaults | n/a |
 | <a name="module_networking"></a> [networking](#module\_networking) | ../_modules/networking | n/a |
 | <a name="module_resource_groups"></a> [resource\_groups](#module\_resource\_groups) | ../_modules/resource_groups | n/a |

--- a/infra/resources/prod/westeurope/custom_roles.tf
+++ b/infra/resources/prod/westeurope/custom_roles.tf
@@ -1,0 +1,4 @@
+module "custom_roles" {
+  source            = "../_modules/custom_roles/"
+  resource_group_id = module.resource_groups.resource_group_fims.id
+}

--- a/infra/resources/prod/westeurope/web_apps.tf
+++ b/infra/resources/prod/westeurope/web_apps.tf
@@ -9,10 +9,6 @@ module "web_apps" {
       {
         name  = "NODE_ENV",
         value = "production"
-      },
-      {
-        name  = "COSMOS_DB_CONNECTION_STRING",
-        value = module.cosmos.cosmos_account_fims_primary_connection_string
       }
     ]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,6 +108,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/core-client@npm:^1.4.0":
+  version: 1.9.2
+  resolution: "@azure/core-client@npm:1.9.2"
+  dependencies:
+    "@azure/abort-controller": "npm:^2.0.0"
+    "@azure/core-auth": "npm:^1.4.0"
+    "@azure/core-rest-pipeline": "npm:^1.9.1"
+    "@azure/core-tracing": "npm:^1.0.0"
+    "@azure/core-util": "npm:^1.6.1"
+    "@azure/logger": "npm:^1.0.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4dab1f3b070f7c2c5a8390f81c7afdf31c030ad0599e75e16b9684959fb666cb57d34b63977639a60a7535f63f30a8a708210e8e48ff68a30732b7518044ebce
+  languageName: node
+  linkType: hard
+
 "@azure/core-paging@npm:^1.1.1":
   version: 1.6.1
   resolution: "@azure/core-paging@npm:1.6.1"
@@ -250,12 +265,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@azure/identity@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@azure/identity@npm:4.1.0"
+  dependencies:
+    "@azure/abort-controller": "npm:^1.0.0"
+    "@azure/core-auth": "npm:^1.5.0"
+    "@azure/core-client": "npm:^1.4.0"
+    "@azure/core-rest-pipeline": "npm:^1.1.0"
+    "@azure/core-tracing": "npm:^1.0.0"
+    "@azure/core-util": "npm:^1.3.0"
+    "@azure/logger": "npm:^1.0.0"
+    "@azure/msal-browser": "npm:^3.11.1"
+    "@azure/msal-node": "npm:^2.6.6"
+    events: "npm:^3.0.0"
+    jws: "npm:^4.0.0"
+    open: "npm:^8.0.0"
+    stoppable: "npm:^1.1.0"
+    tslib: "npm:^2.2.0"
+  checksum: 10c0/6b8349c334dc76324a1c64f69418ca8b3ef96e5c9f96ddf1ee08e56fdffcffd4828471e0f8620e287675fe210a7c08191f4dad87d62a21678525dcfb89c9e510
+  languageName: node
+  linkType: hard
+
 "@azure/logger@npm:*, @azure/logger@npm:^1.0.0":
   version: 1.1.1
   resolution: "@azure/logger@npm:1.1.1"
   dependencies:
     tslib: "npm:^2.6.2"
   checksum: 10c0/79014d78774b7a24c236a9c83550e9769c39cb6d4469c23ab35998dd1a67fed8fd43c947eb7382cdeab826747fa7fabc686a37e4aee67535cc6ce5e0302c9323
+  languageName: node
+  linkType: hard
+
+"@azure/msal-browser@npm:^3.11.1":
+  version: 3.13.0
+  resolution: "@azure/msal-browser@npm:3.13.0"
+  dependencies:
+    "@azure/msal-common": "npm:14.9.0"
+  checksum: 10c0/093c6f8f42cfdf8376cc6f42fa007c5ec926cf969ac75fb1f65836dbd1e531770ebeaf80e795496bef6ab2903f6c30b1593d7ddbad0320e609b49ad5d18b066e
+  languageName: node
+  linkType: hard
+
+"@azure/msal-common@npm:14.9.0":
+  version: 14.9.0
+  resolution: "@azure/msal-common@npm:14.9.0"
+  checksum: 10c0/534a7f15a3bb87cbdf12a0138465fb1de68fc10c1caee7fcd4a3582dd8fb29fad2d4f3d55e0e1647b9e0afd7eee6de81c6d53cb7f94f43c9ab41909d376f8d80
+  languageName: node
+  linkType: hard
+
+"@azure/msal-node@npm:^2.6.6":
+  version: 2.7.0
+  resolution: "@azure/msal-node@npm:2.7.0"
+  dependencies:
+    "@azure/msal-common": "npm:14.9.0"
+    jsonwebtoken: "npm:^9.0.0"
+    uuid: "npm:^8.3.0"
+  checksum: 10c0/8448b50dc4bf64aa9b42aa32d32cbbd6edc07bab2f470f5ebf69d5b9580718f1354c3e81ead9c315a37082e65f9b6cf297de1d7e3b11816e890c2848dcdc83a3
   languageName: node
   linkType: hard
 
@@ -5994,6 +6058,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"define-lazy-prop@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "define-lazy-prop@npm:2.0.0"
+  checksum: 10c0/db6c63864a9d3b7dc9def55d52764968a5af296de87c1b2cc71d8be8142e445208071953649e0386a8cc37cfcf9a2067a47207f1eb9ff250c2a269658fdae422
+  languageName: node
+  linkType: hard
+
 "define-properties@npm:^1.1.3, define-properties@npm:^1.2.0, define-properties@npm:^1.2.1":
   version: 1.2.1
   resolution: "define-properties@npm:1.2.1"
@@ -7414,6 +7485,13 @@ __metadata:
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
   checksum: 10c0/0255d9f936215fd206156fd4caa9e8d35e62075d720dc7d847e89b417e5e62cf1ce6c9b4e0a1633a9256de0efefaf9f8d26924b1f3c8620cffb9db78e7d3076b
+  languageName: node
+  linkType: hard
+
+"events@npm:^3.0.0":
+  version: 3.3.0
+  resolution: "events@npm:3.3.0"
+  checksum: 10c0/d6b6f2adbccbcda74ddbab52ed07db727ef52e31a61ed26db9feb7dc62af7fc8e060defa65e5f8af9449b86b52cc1a1f6a79f2eafcf4e62add2b7a1fa4a432f6
   languageName: node
   linkType: hard
 
@@ -9624,6 +9702,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-docker@npm:^2.0.0, is-docker@npm:^2.1.1":
+  version: 2.2.1
+  resolution: "is-docker@npm:2.2.1"
+  bin:
+    is-docker: cli.js
+  checksum: 10c0/e828365958d155f90c409cdbe958f64051d99e8aedc2c8c4cd7c89dcf35329daed42f7b99346f7828df013e27deb8f721cf9408ba878c76eb9e8290235fbcdcc
+  languageName: node
+  linkType: hard
+
 "is-extendable@npm:^0.1.0, is-extendable@npm:^0.1.1":
   version: 0.1.1
   resolution: "is-extendable@npm:0.1.1"
@@ -9990,6 +10077,15 @@ __metadata:
   version: 1.0.4
   resolution: "is-word-character@npm:1.0.4"
   checksum: 10c0/2247844064532986dc70869d961dccd1366932a147b52d4ec7f567f87edf7f9855a27b75f66b781db3b3175bbe05a76acbc6392a1a5c64c4c99fe3459dae33bd
+  languageName: node
+  linkType: hard
+
+"is-wsl@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "is-wsl@npm:2.2.0"
+  dependencies:
+    is-docker: "npm:^2.0.0"
+  checksum: 10c0/a6fa2d370d21be487c0165c7a440d567274fbba1a817f2f0bfa41cc5e3af25041d84267baa22df66696956038a43973e72fca117918c91431920bdef490fa25e
   languageName: node
   linkType: hard
 
@@ -10994,7 +11090,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonwebtoken@npm:^9.0.1":
+"jsonwebtoken@npm:^9.0.0, jsonwebtoken@npm:^9.0.1":
   version: 9.0.2
   resolution: "jsonwebtoken@npm:9.0.2"
   dependencies:
@@ -11080,6 +11176,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jwa@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "jwa@npm:2.0.0"
+  dependencies:
+    buffer-equal-constant-time: "npm:1.0.1"
+    ecdsa-sig-formatter: "npm:1.0.11"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/6baab823b93c038ba1d2a9e531984dcadbc04e9eb98d171f4901b7a40d2be15961a359335de1671d78cb6d987f07cbe5d350d8143255977a889160c4d90fcc3c
+  languageName: node
+  linkType: hard
+
 "jws@npm:^3.2.2":
   version: 3.2.2
   resolution: "jws@npm:3.2.2"
@@ -11087,6 +11194,16 @@ __metadata:
     jwa: "npm:^1.4.1"
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/e770704533d92df358adad7d1261fdecad4d7b66fa153ba80d047e03ca0f1f73007ce5ed3fbc04d2eba09ba6e7e6e645f351e08e5ab51614df1b0aa4f384dfff
+  languageName: node
+  linkType: hard
+
+"jws@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jws@npm:4.0.0"
+  dependencies:
+    jwa: "npm:^2.0.0"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/f1ca77ea5451e8dc5ee219cb7053b8a4f1254a79cb22417a2e1043c1eb8a569ae118c68f24d72a589e8a3dd1824697f47d6bd4fb4bebb93a3bdf53545e721661
   languageName: node
   linkType: hard
 
@@ -13280,6 +13397,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"open@npm:^8.0.0":
+  version: 8.4.2
+  resolution: "open@npm:8.4.2"
+  dependencies:
+    define-lazy-prop: "npm:^2.0.0"
+    is-docker: "npm:^2.1.1"
+    is-wsl: "npm:^2.2.0"
+  checksum: 10c0/bb6b3a58401dacdb0aad14360626faf3fb7fba4b77816b373495988b724fb48941cad80c1b65d62bb31a17609b2cd91c41a181602caea597ca80dfbcc27e84c9
+  languageName: node
+  linkType: hard
+
 "openapi-schema-validation@npm:^0.4.2":
   version: 0.4.2
   resolution: "openapi-schema-validation@npm:0.4.2"
@@ -13368,6 +13496,7 @@ __metadata:
   dependencies:
     "@azure/cosmos": "npm:^4.0.0"
     "@azure/functions": "npm:^3.2.0"
+    "@azure/identity": "npm:^4.1.0"
     "@pagopa/io-functions-commons": "npm:^29.0.0"
     "@pagopa/openapi-codegen-ts": "npm:^10.0.6"
     "@pagopa/ts-commons": "npm:^10.2.1"
@@ -15172,6 +15301,7 @@ __metadata:
   dependencies:
     "@azure/cosmos": "npm:^4.0.0"
     "@azure/functions": "npm:^4.3.0"
+    "@azure/identity": "npm:^4.1.0"
     "@pagopa/handler-kit": "npm:^1.1.0"
     "@pagopa/handler-kit-azure-func": "npm:^2.0.3"
     "@pagopa/logger": "npm:^1.0.1"
@@ -15950,6 +16080,13 @@ __metadata:
   version: 3.7.0
   resolution: "std-env@npm:3.7.0"
   checksum: 10c0/60edf2d130a4feb7002974af3d5a5f3343558d1ccf8d9b9934d225c638606884db4a20d2fe6440a09605bca282af6b042ae8070a10490c0800d69e82e478f41e
+  languageName: node
+  linkType: hard
+
+"stoppable@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "stoppable@npm:1.1.0"
+  checksum: 10c0/ba91b65e6442bf6f01ce837a727ece597a977ed92a05cb9aea6bf446c5e0dcbccc28f31b793afa8aedd8f34baaf3335398d35f903938d5493f7fbe386a1e090e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->

* [Add a new custom-role](https://github.com/pagopa/io-fims/commit/f3ef8e8a39db972353338d44b43356638778f6a0);
* [refactor(rp-func): replace cosmos connection string with default cred…](https://github.com/pagopa/io-fims/commit/3bb86165ff63e8f8e52a163a029f9fa7e6fdaa08);
* [refactor(openid-provider-app): replace cosmos connection string with …](https://github.com/pagopa/io-fims/commit/2220ceaffb5167ab9a48ad3be55c423c801f36f7)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->

We want to create a new custom role in order to connect to cosmos and perform queries without using the connection string.

### Type of changes

- [x] Add new resources
- [ ] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
