### PR TITLE
fix: move to built-in sql role

### DIFF
--- a/infra/resources/prod/_modules/cosmos/cosmos_account_fims.tf
+++ b/infra/resources/prod/_modules/cosmos/cosmos_account_fims.tf
@@ -1,17 +1,3 @@
-resource "azurerm_role_definition" "cosmos_query" {
-  name        = "CosmosDB Data Operator"
-  scope       = module.cosmosdb_account_fims.id
-  description = "Can query CosmosDB containers"
-
-  permissions {
-    actions = ["Microsoft.DocumentDB/databaseAccounts/readMetadata", "Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/items/*"]
-  }
-
-  assignable_scopes = [
-    module.cosmosdb_account_fims.id
-  ]
-}
-
 module "cosmosdb_account_fims" {
   source = "github.com/pagopa/terraform-azurerm-v3//cosmosdb_account?ref=v7.67.1"
 

--- a/infra/resources/prod/_modules/cosmos/outputs.tf
+++ b/infra/resources/prod/_modules/cosmos/outputs.tf
@@ -11,22 +11,6 @@ output "cosmos_fims" {
   }
 }
 
-output "cosmos_account_fims_endpoint" {
-  value     = module.cosmosdb_account_fims.endpoint
-  sensitive = true
-}
-
-output "cosmos_account_fims_primary_key" {
-  value     = module.cosmosdb_account_fims.primary_key
-  sensitive = true
-}
-
-output "cosmos_account_fims_id" {
-  value     = module.cosmosdb_account_fims.id
-  sensitive = true
-}
-
-output "cosmos_query_role_definition_id" {
-  value     = resource.azurerm_role_definition.cosmos_query.role_definition_id
-  sensitive = false
+output "account_name" {
+  value = module.cosmosdb_account_fims.name
 }

--- a/infra/resources/prod/_modules/web_apps/app_service_openid_provider.tf
+++ b/infra/resources/prod/_modules/web_apps/app_service_openid_provider.tf
@@ -1,9 +1,3 @@
-resource "azurerm_role_assignment" "app_service_op_cosmos_query" {
-  scope              = var.cosmos_account_id
-  role_definition_id = var.cosmos_query_role_definition_id
-  principal_id       = module.appservice_openid_provider.principal_id
-}
-
 module "appservice_openid_provider" {
   source = "github.com/pagopa/terraform-azurerm-v3//app_service?ref=v7.67.1"
 
@@ -39,10 +33,12 @@ module "appservice_openid_provider" {
   tags = var.tags
 }
 
-resource "azurerm_role_assignment" "app_service_staging_op_cosmos_query" {
-  scope              = var.cosmos_account_id
-  role_definition_id = var.cosmos_query_role_definition_id
-  principal_id       = module.appservice_openid_provider_staging.principal_id
+resource "azurerm_cosmosdb_sql_role_assignment" "op_app_sql_role" {
+  resource_group_name = data.azurerm_cosmosdb_account.fims.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.fims.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.fims.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = module.appservice_openid_provider.principal_id
+  scope               = data.azurerm_cosmosdb_account.fims.id
 }
 
 module "appservice_openid_provider_staging" {
@@ -76,4 +72,12 @@ module "appservice_openid_provider_staging" {
   vnet_integration = true
 
   tags = var.tags
+}
+
+resource "azurerm_cosmosdb_sql_role_assignment" "op_app_staging_sql_role" {
+  resource_group_name = data.azurerm_cosmosdb_account.fims.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.fims.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.fims.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = module.appservice_openid_provider_staging.principal_id
+  scope               = data.azurerm_cosmosdb_account.fims.id
 }

--- a/infra/resources/prod/_modules/web_apps/data.tf
+++ b/infra/resources/prod/_modules/web_apps/data.tf
@@ -47,4 +47,9 @@ data "azurerm_key_vault_secret" "jwk_primary_key_fims" {
   key_vault_id = var.key_vault_id
 }
 
+data "azurerm_cosmosdb_account" "fims" {
+  name                = var.cosmosdb_account.name
+  resource_group_name = var.cosmosdb_account.resource_group_name
+}
+
 data "azurerm_client_config" "current" {}

--- a/infra/resources/prod/_modules/web_apps/function_op.tf
+++ b/infra/resources/prod/_modules/web_apps/function_op.tf
@@ -33,6 +33,14 @@ resource "azurerm_key_vault_access_policy" "openid_provider_func_key_vault_acces
   certificate_permissions = []
 }
 
+resource "azurerm_cosmosdb_sql_role_assignment" "op_func_sql_role" {
+  resource_group_name = data.azurerm_cosmosdb_account.fims.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.fims.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.fims.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = module.op_func.system_identity_principal
+  scope               = data.azurerm_cosmosdb_account.fims.id
+}
+
 module "op_func_staging_slot" {
   source = "github.com/pagopa/terraform-azurerm-v3.git//function_app_slot?ref=v7.72.2"
 

--- a/infra/resources/prod/_modules/web_apps/function_rp.tf
+++ b/infra/resources/prod/_modules/web_apps/function_rp.tf
@@ -1,9 +1,3 @@
-resource "azurerm_role_assignment" "rp_func_cosmos_query" {
-  scope              = var.cosmos_account_id
-  role_definition_id = var.cosmos_query_role_definition_id
-  principal_id       = module.relying_party_func.system_identity_principal
-}
-
 module "relying_party_func" {
   source = "github.com/pagopa/terraform-azurerm-v3.git//function_app?ref=v7.72.2"
 
@@ -43,6 +37,14 @@ resource "azurerm_key_vault_access_policy" "relying_party_func_key_vault_access_
   secret_permissions      = ["Get"]
   storage_permissions     = []
   certificate_permissions = []
+}
+
+resource "azurerm_cosmosdb_sql_role_assignment" "rp_func_sql_role" {
+  resource_group_name = data.azurerm_cosmosdb_account.fims.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.fims.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.fims.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = module.relying_party_func.system_identity_principal
+  scope               = data.azurerm_cosmosdb_account.fims.id
 }
 
 module "relying_party_func_staging_slot" {

--- a/infra/resources/prod/_modules/web_apps/function_user.tf
+++ b/infra/resources/prod/_modules/web_apps/function_user.tf
@@ -46,6 +46,14 @@ resource "azurerm_key_vault_access_policy" "user_func_key_vault_access_policy" {
   certificate_permissions = []
 }
 
+resource "azurerm_cosmosdb_sql_role_assignment" "user_func_sql_role" {
+  resource_group_name = data.azurerm_cosmosdb_account.fims.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.fims.name
+  role_definition_id  = "${data.azurerm_cosmosdb_account.fims.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"
+  principal_id        = module.user_func.system_identity_principal
+  scope               = data.azurerm_cosmosdb_account.fims.id
+}
+
 module "user_func_staging_slot" {
   source = "github.com/pagopa/terraform-azurerm-v3.git//function_app_slot?ref=v7.72.2"
 

--- a/infra/resources/prod/_modules/web_apps/locals.tf
+++ b/infra/resources/prod/_modules/web_apps/locals.tf
@@ -36,8 +36,7 @@ locals {
       IO_BACKEND_BASE_URL             = "https://api-app.io.pagopa.it"
       VERSION                         = "0.0.1"
       COSMOSDB_NAME                   = "fims"
-      COSMOSDB_URI                    = var.cosmos_db.endpoint
-      COSMOSDB_KEY                    = var.cosmos_db.primary_key
+      COSMOSDB_URI                    = data.azurerm_cosmosdb_account.fims.endpoint
       AUTHENTICATION_COOKIE_KEY       = "X-IO-FIMS-Token"
       GRANT_TTL_IN_SECONDS            = "86400"
       ISSUER                          = "https://io-p-fims-oidc-provider-app.azurewebsites.net"

--- a/infra/resources/prod/_modules/web_apps/variables.tf
+++ b/infra/resources/prod/_modules/web_apps/variables.tf
@@ -23,21 +23,11 @@ variable "subnet_id" {
   type = string
 }
 
-variable "cosmos_db" {
+variable "cosmosdb_account" {
   type = object({
-    endpoint    = string
-    primary_key = string
+    name                = string
+    resource_group_name = string
   })
-
-  sensitive = true
-}
-
-variable "cosmos_account_id" {
-  type = string
-}
-
-variable "cosmos_query_role_definition_id" {
-  type = string
 }
 
 variable "key_vault_id" {

--- a/infra/resources/prod/westeurope/web_apps.tf
+++ b/infra/resources/prod/westeurope/web_apps.tf
@@ -1,9 +1,6 @@
 module "web_apps" {
   source = "../_modules/web_apps"
 
-  cosmos_account_id               = module.cosmos.cosmos_account_fims_id
-  cosmos_query_role_definition_id = module.cosmos.cosmos_query_role_definition_id
-
   rp_func = {
     autoscale_default = 1
     autoscale_minimum = 1
@@ -46,9 +43,9 @@ module "web_apps" {
   resource_group_name = module.resource_groups.resource_group_fims.name
   subnet_id           = module.networking.subnet_fims.id
 
-  cosmos_db = {
-    endpoint    = module.cosmos.cosmos_account_fims_endpoint
-    primary_key = module.cosmos.cosmos_account_fims_primary_key
+  cosmosdb_account = {
+    name                = module.cosmos.account_name
+    resource_group_name = module.resource_groups.resource_group_fims.name
   }
 
   key_vault_id = module.key_vaults.key_vault_fims.id


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

1. replaced the custom `azurerm_role` definition/assignment with a built-in `sql_role`

<!--- Describe your changes in detail -->

### Motivation and context
The previous defined role didn't work as intended. In general, `azurerm_roles` are used for resource management. For database access, Azure provided `sql_role` with good built-in ones.

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [x] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [x] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
