### PR TITLE
ci(code-review): switch to reusable workflow

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -1,52 +1,15 @@
-name: "Code Review"
+name: Code Review
 
 on:
-  push:
-    branches: ["main"]
-    paths:
-      - apps/**
-      - packages/**
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
     paths:
       - apps/**
       - packages/**
-  workflow_dispatch: {}
 
 jobs:
-  code_review:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
-        with:
-          fetch-depth: 2
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Setup Node.js environment
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
-        with:
-          node-version-file: ".node-version"
-          cache: "yarn"
-
-      - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Cache turbo build setup
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: node_modules/.cache/turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      - name: "Code review"
-        run: yarn run code-review
-
-      - name: "Upload to codecov.io"
-        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed # v4.3.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+  js_code_review:
+    uses: pagopa/dx/.github/workflows/js_code_review.yaml@44d30b91731e81d3d5eb03937ee07358d8beb884
+    name: Code Review
+    secrets: inherit


### PR DESCRIPTION
### List of changes
1. `code-review` workflow now uses the reusable workflow from `pagopa/dx` (https://github.com/pagopa/dx/pull/13)

