### PR TITLE
Enable client auth method and trust proxy on OP

### DIFF
--- a/apps/op-app/src/adapters/oidc/provider.ts
+++ b/apps/op-app/src/adapters/oidc/provider.ts
@@ -29,10 +29,6 @@ export function createProvider(
         enabled: false,
       },
     },
-    routes: {
-      authorization: "/authorize",
-      userinfo: "/userinfo",
-    },
     findAccount: findAccount({ sessionRepository }),
     pkce: {
       required: () => false,
@@ -42,6 +38,10 @@ export function createProvider(
       ctx.body = out;
     },
     responseTypes: ["code", "id_token"],
+    routes: {
+      authorization: "/authorize",
+      userinfo: "/userinfo",
+    },
     ttl: {
       AccessToken: 60,
       AuthorizationCode: 60,

--- a/apps/op-app/src/adapters/oidc/provider.ts
+++ b/apps/op-app/src/adapters/oidc/provider.ts
@@ -4,21 +4,23 @@ import Provider, * as oidc from "oidc-provider";
 
 import { findAccount } from "./account.js";
 
-export const createProvider = (
+const oidcClaims: oidc.Configuration["claims"] = Object.entries(claims).reduce(
+  (acc, [scope, claims]) => ({
+    ...acc,
+    [scope]: [...claims],
+  }),
+  {},
+);
+
+export function createProvider(
   issuer: string,
   sessionRepository: SessionRepository,
   adapter: oidc.AdapterConstructor | oidc.AdapterFactory,
-): Provider =>
-  new Provider(issuer, {
+) {
+  const provider = new Provider(issuer, {
     adapter,
-    claims: Object.entries(claims).reduce(
-      (acc, [scope, claims]) => ({
-        ...acc,
-        [scope]: [...claims],
-      }),
-      {},
-    ),
-    clientAuthMethods: ["none"],
+    claims: oidcClaims,
+    clientAuthMethods: ["client_secret_basic"],
     extraClientMetadata: {
       properties: ["redirect_display_names"],
     },
@@ -45,3 +47,8 @@ export const createProvider = (
       Session: 5 * 60,
     },
   });
+  // Configure the OIDC provider to trust the X-Forwarded-* headers.
+  // https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#trusting-tls-offloading-proxies
+  provider.proxy = true;
+  return provider;
+}

--- a/apps/op-app/src/adapters/oidc/provider.ts
+++ b/apps/op-app/src/adapters/oidc/provider.ts
@@ -29,6 +29,10 @@ export function createProvider(
         enabled: false,
       },
     },
+    routes: {
+      authorization: "/authorize",
+      userinfo: "/userinfo",
+    },
     findAccount: findAccount({ sessionRepository }),
     pkce: {
       required: () => false,

--- a/apps/op-func/src/adapters/handlers/create-oidc-client.ts
+++ b/apps/op-func/src/adapters/handlers/create-oidc-client.ts
@@ -14,7 +14,7 @@ export const inputDecoder = iotsCodecFromZod(oidcClientConfigSchema);
 export const createOIDCClientHandler = H.of((clientConfig: OIDCClientConfig) =>
   pipe(
     parseClientMetadataFromConfig(clientConfig),
-    RTE.fromEither,
+    RTE.fromIOEither,
     RTE.flatMap(createOIDCClient),
   ),
 );

--- a/packages/io-fims-common/src/domain/client-metadata.ts
+++ b/packages/io-fims-common/src/domain/client-metadata.ts
@@ -1,3 +1,7 @@
+import { sequenceS } from "fp-ts/lib/Apply.js";
+import * as IO from "fp-ts/lib/IO.js";
+import { flow, pipe } from "fp-ts/lib/function.js";
+import * as crypto from "node:crypto";
 import { z } from "zod";
 
 import { parse } from "../parse.js";
@@ -7,16 +11,19 @@ const clientMetadataSchema = z
   .object({
     client_id: z.string().ulid(),
     client_id_issued_at: z.number(),
-    grant_types: z.tuple([z.literal("authorization_code")]),
+    client_secret: z.string().min(1),
+    grant_types: z.array(z.enum(["implicit", "authorization_code"])),
     redirect_display_names: z.record(
-      z.object({
-        en: z.string().optional(),
-        it: z.string().min(1),
-      }),
+      z.intersection(
+        z.record(z.string()),
+        z.object({
+          it: z.string().min(1),
+        }),
+      ),
     ),
     redirect_uris: z.array(z.string().url()),
-    response_types: z.tuple([z.literal("code")]),
-    token_endpoint_auth_method: z.literal("none"),
+    response_types: z.array(z.enum(["code", "id_token"])),
+    token_endpoint_auth_method: z.literal("client_secret_basic"),
   })
   .refine(
     (arg) =>
@@ -28,24 +35,33 @@ const clientMetadataSchema = z
 
 export type ClientMetadata = z.TypeOf<typeof clientMetadataSchema>;
 
-export const clientMetadataFromConfig = (
+const clientMetadataFromConfig = (
   config: OIDCClientConfig,
-): ClientMetadata =>
-  clientMetadataSchema.parse({
-    client_id: config.id,
-    client_id_issued_at: Date.now(),
-    grant_types: ["authorization_code"],
-    redirect_display_names: config.callbacks.reduce(
-      (redirectDisplayNames, { displayName, uri }) => ({
-        ...redirectDisplayNames,
-        [uri]: displayName,
-      }),
-      {},
-    ),
-    redirect_uris: config.callbacks.map((cb) => cb.uri),
-    response_types: ["code"],
-    token_endpoint_auth_method: "none",
-  });
+): IO.IO<ClientMetadata> =>
+  pipe(
+    sequenceS(IO.Apply)({
+      client_id_issued_at: () => Date.now(),
+      client_secret: () => crypto.randomBytes(32).toString("base64"),
+    }),
+    IO.map(({ client_id_issued_at, client_secret }) => ({
+      client_id: config.id,
+      client_id_issued_at,
+      client_secret,
+      grant_types: ["authorization_code"],
+      redirect_display_names: config.callbacks.reduce(
+        (redirectDisplayNames, { displayName, uri }) => ({
+          ...redirectDisplayNames,
+          [uri]: displayName,
+        }),
+        {},
+      ),
+      redirect_uris: config.callbacks.map((cb) => cb.uri),
+      response_types: ["code"],
+      token_endpoint_auth_method: "client_secret_basic",
+    })),
+  );
 
-export const parseClientMetadataFromConfig = (config: OIDCClientConfig) =>
-  parse(clientMetadataSchema)(clientMetadataFromConfig(config));
+export const parseClientMetadataFromConfig = flow(
+  clientMetadataFromConfig,
+  IO.map(parse(clientMetadataSchema)),
+);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. Enable `client_secret_basic` as auth method of `/token` endpoint
2. Enable proxy setting for `oidc-provider`
3. Change route names (`/auth` -> `/authorize`, `/me` -> `/userinfo`) to use the standard ones