### PR TITLE
fix(infra): add storage blob data contributor role

### DIFF
--- a/infra/identity/prod/federated_identities.tf
+++ b/infra/identity/prod/federated_identities.tf
@@ -43,10 +43,12 @@ module "federated_identities" {
           "Storage Blob Data Contributor"
         ]
         io-p-fims-rg = [
-          "Role Based Access Control Administrator"
+          "Role Based Access Control Administrator",
+          "Storage Blob Data Contributor"
         ],
         io-p-weu-fims-rg-01 = [
-          "Role Based Access Control Administrator"
+          "Role Based Access Control Administrator",
+          "Storage Blob Data Contributor"
         ]
       }
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. Add `Storage Blob Data Contributor` to `CD` identity for `io-p-fims-rg` and `io-p-weu-fims-rg-01` resource group

<!--- Describe your changes in detail -->

### Motivation and context
This role is required to apply infrastructure changes that affect `Blob Storage` resources

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new resources
- [x] Update configuration to existing resources
- [ ] Remove existing resources

### Env to apply

- [ ] DEV
- [ ] UAT
- [x] PROD

### Does this introduce a change to production resources with possible user impact?

- [ ] Yes, users may be impacted applying this change
- [ ] No

### Does this introduce an unwanted change on infrastructure? Check terraform plan execution result

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
