### PR TITLE
chore: Claim type for user_metadata

### DIFF
--- a/apps/op-app/openapi.yaml
+++ b/apps/op-app/openapi.yaml
@@ -233,6 +233,17 @@ components:
       required:
         - href
 
+    Claim:
+      type: object
+      properties:
+        name:
+          type: string
+        display_name:
+          type: string
+      required:
+        - name
+        - display_name
+
     Consent:
       type: object
       properties:
@@ -265,15 +276,7 @@ components:
         user_metadata:
           type: array
           items:
-            type: object
-            properties:
-              name:
-                type: string
-              display_name:
-                type: string
-            required:
-              - name
-              - display_name
+            $ref: "#/components/schemas/Claim"
       required:
         - _links
         - service_id


### PR DESCRIPTION
### List of changes
- Added `Claim` specification to `schemas` in `apps/op-app/openapi.yaml`
- `Claim` specification linked to the array type of `user_metadata` in `Consent` schema

### Motivation and context
This change is required otherwise the codegen does not properly infer the type of `user_metadata`, assigning to it an array of generic objects.
