### PR TITLE
fix: use the right mailup credentials

### DIFF
--- a/infra/resources/_modules/web_apps_itn/user_func.tf
+++ b/infra/resources/_modules/web_apps_itn/user_func.tf
@@ -25,14 +25,14 @@ module "user_func" {
 
   resource_group_name = var.resource_group_name
 
-  health_check_path = "/api/health"
+  health_check_path = local.user_func.common_app_settings.WEBSITE_WARMUP_PATH
 
   application_insights_connection_string = var.application_insights.connection_string
 
   app_settings = merge(local.user_func.common_app_settings, {
     NODE_ENV        = "production",
-    MAILUP_SECRET   = "@Microsoft.KeyVault(VaultName=${var.key_vault_common.name};SecretName=common-MAILUP-SECRET)",
-    MAILUP_USERNAME = "@Microsoft.KeyVault(VaultName=${var.key_vault_common.name};SecretName=common-MAILUP-USERNAME)",
+    MAILUP_SECRET   = "@Microsoft.KeyVault(VaultName=${var.key_vault.name};SecretName=mailup-secret)",
+    MAILUP_USERNAME = "@Microsoft.KeyVault(VaultName=${var.key_vault.name};SecretName=mailup-username)",
   })
 
   slot_app_settings = merge(local.user_func.common_app_settings, {
@@ -68,7 +68,7 @@ resource "azurerm_cosmosdb_sql_role_assignment" "user_func" {
 }
 
 resource "azurerm_key_vault_access_policy" "user_func" {
-  key_vault_id = var.key_vault_common.id
+  key_vault_id = var.key_vault.id
   tenant_id    = data.azurerm_client_config.current.tenant_id
   object_id    = module.user_func.function_app.function_app.principal_id
 

--- a/infra/resources/_modules/web_apps_itn/user_func.tf
+++ b/infra/resources/_modules/web_apps_itn/user_func.tf
@@ -67,12 +67,8 @@ resource "azurerm_cosmosdb_sql_role_assignment" "user_func" {
   scope               = data.azurerm_cosmosdb_account.fims.id
 }
 
-resource "azurerm_key_vault_access_policy" "user_func" {
-  key_vault_id = var.key_vault.id
-  tenant_id    = data.azurerm_client_config.current.tenant_id
-  object_id    = module.user_func.function_app.function_app.principal_id
-
-  secret_permissions = [
-    "Get",
-  ]
+resource "azurerm_role_assignment" "key_vault_user_func" {
+  scope                = var.key_vault.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = module.user_func.function_app.function_app.principal_id
 }

--- a/infra/resources/_modules/web_apps_itn/variables.tf
+++ b/infra/resources/_modules/web_apps_itn/variables.tf
@@ -43,13 +43,6 @@ variable "key_vault" {
   })
 }
 
-variable "key_vault_common" {
-  type = object({
-    id   = string
-    name = string
-  })
-}
-
 variable "cosmosdb_account" {
   type = object({
     name                = string

--- a/infra/resources/prod/web_apps.tf
+++ b/infra/resources/prod/web_apps.tf
@@ -65,5 +65,4 @@ module "web_apps_itn" {
   storage              = module.storage.fims
   audit_storage        = module.storage.audit
   application_insights = data.azurerm_application_insights.common
-  key_vault_common     = module.key_vaults.common
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. Use the mailup credentials from fims keyvault instead the common one

<!--- Describe your changes in detail -->

### Motivation and context
We would like to avoid sharing credentials with other teams and services