### PR TITLE
feat(op): implicit consent for internal rp

### DIFF
--- a/apps/op-app/src/adapters/oidc/provider.ts
+++ b/apps/op-app/src/adapters/oidc/provider.ts
@@ -27,7 +27,7 @@ export function createProvider(
       keys: cookieKeys,
     },
     extraClientMetadata: {
-      properties: ["redirect_display_names"],
+      properties: ["redirect_display_names", "is_internal"],
     },
     features: {
       customKeyStore: {

--- a/packages/io-fims-common/src/domain/client-metadata.ts
+++ b/packages/io-fims-common/src/domain/client-metadata.ts
@@ -13,6 +13,7 @@ const clientMetadataSchema = z
     client_id_issued_at: z.number(),
     client_secret: z.string().min(1),
     grant_types: z.array(z.enum(["implicit", "authorization_code"])),
+    is_internal: z.boolean(),
     redirect_display_names: z.record(
       z.intersection(
         z.record(z.string()),
@@ -48,6 +49,7 @@ const clientMetadataFromConfig = (
       client_id_issued_at,
       client_secret,
       grant_types: ["authorization_code"],
+      is_internal: false,
       redirect_display_names: config.callbacks.reduce(
         (redirectDisplayNames, { displayName, uri }) => ({
           ...redirectDisplayNames,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
1. Add a new, optional metadata for `Client` called `is_internal` (_Boolean_). Setting `is_internal` to `true` means that the external web services referenced by the client metadata (via `redirect_uri`) is managed by `PagoPA S.p.A.` 
2. Authentication Requests originated by _internal_ clients no longer require explicit consent by the citizen.
<!--- Describe your changes in detail -->

### Motivation and context
Internal client does not need an explicit consent by the citizen cause the data will not be shared with third parties.

<!--- Why is this change required? What problem does it solve? -->