### PR TITLE
Fix validation bug with multiple zod versions

### DIFF
--- a/apps/op-app/src/adapters/oidc/provider.ts
+++ b/apps/op-app/src/adapters/oidc/provider.ts
@@ -1,8 +1,9 @@
 import { SessionRepository } from "@/domain/session.js";
 import { claims } from "@/domain/user-metadata.js";
-import { redirectDisplayNameSchema } from "io-fims-common/domain/redirect-display-name";
+import { redirectDisplayNamesSchema } from "io-fims-common/domain/redirect-display-name";
 import Provider, * as oidc from "oidc-provider";
-import { z } from "zod";
+
+import * as assert from "node:assert/strict";
 
 import { findAccount } from "./account.js";
 
@@ -37,12 +38,10 @@ export function createProvider(
           );
         }
         if (key === "redirect_display_names") {
-          const result = z
-            .record(z.string().url(), redirectDisplayNameSchema)
-            .safeParse(value);
+          const result = redirectDisplayNamesSchema.safeParse(value);
           if (!result.success) {
             throw new oidc.errors.InvalidClientMetadata(
-              "malformed redirect_display_names",
+              `malformed redirect_display_names: ${result.error.message}`,
             );
           }
         }

--- a/packages/io-fims-common/src/domain/redirect-display-name.ts
+++ b/packages/io-fims-common/src/domain/redirect-display-name.ts
@@ -6,3 +6,8 @@ export const redirectDisplayNameSchema = z.object({
   en: displayNameSchema.optional(),
   it: displayNameSchema,
 });
+
+export const redirectDisplayNamesSchema = z.record(
+  z.string().url(),
+  redirectDisplayNameSchema,
+);


### PR DESCRIPTION
Some runtime validations are broken on production due to a bug on `zod` that apparently can't handle custom schemas composed by subschemas from different packages.

With this change the code will use a new schema from `io-fims-common` instead of building a custom one.