### PR TITLE
Bump tf modules version

### DIFF
--- a/infra/resources/_modules/resource_group/main.tf
+++ b/infra/resources/_modules/resource_group/main.tf
@@ -7,7 +7,8 @@ terraform {
 }
 
 module "naming_convention" {
-  source      = "github.com/pagopa/dx//infra/modules/azure_naming_convention?ref=5f795b96d84a866de514ab32199ba3f54286f702"
+  source      = "pagopa-dx/azure-naming-convention/azurerm"
+  version     = "0.0.7"
   environment = var.environment
 }
 

--- a/infra/resources/_modules/storage_itn/audit.tf
+++ b/infra/resources/_modules/storage_itn/audit.tf
@@ -1,6 +1,6 @@
 module "storage_account_audit_st_itn" {
   source  = "pagopa-dx/azure-storage-account/azurerm"
-  version = "0.0.9"
+  version = "1.0.1"
 
   subnet_pep_id       = var.subnet_pep_id
   tags                = var.tags

--- a/infra/resources/_modules/storage_itn/fims.tf
+++ b/infra/resources/_modules/storage_itn/fims.tf
@@ -1,6 +1,6 @@
 module "storage_account_fims_itn" {
   source  = "pagopa-dx/azure-storage-account/azurerm"
-  version = "0.0.9"
+  version = "1.0.1"
 
   subnet_pep_id       = var.subnet_pep_id
   tags                = var.tags

--- a/infra/resources/prod/tfmodules.lock.json
+++ b/infra/resources/prod/tfmodules.lock.json
@@ -11,28 +11,28 @@
     "name": "azure_app_service_plan_autoscaler",
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-app-service-plan-autoscaler/azurerm/1.1.3"
   },
-  "storage_itn.storage_account_fims_itn": {
-    "hash": "c073e41130034acebff0c22a7cffc22a1533ef46b64752789d472116abc21eee",
-    "version": "0.0.9",
-    "name": "azure_storage_account",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/0.0.9"
-  },
-  "storage_itn.storage_account_fims_itn.naming_convention": {
-    "hash": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
-    "version": "0.0.5",
+  "itn_resource_group.naming_convention": {
+    "hash": "d7973237e601af346ca3cc8797623f4edff8bdb94b661453d4242609f8d49118",
+    "version": "0.0.7",
     "name": "azure_naming_convention",
-    "source": "https://registry.terraform.io/modules/pagopa/dx-azure-naming-convention/azurerm/0.0.5"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-naming-convention/azurerm/0.0.7"
   },
   "storage_itn.storage_account_audit_st_itn": {
-    "hash": "c073e41130034acebff0c22a7cffc22a1533ef46b64752789d472116abc21eee",
-    "version": "0.0.9",
+    "hash": "a2a257b25753f91b36acef29e080efc4d62dea59e803f56e33e813e7a343e66b",
+    "version": "1.0.1",
     "name": "azure_storage_account",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/0.0.9"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/1.0.1"
   },
-  "storage_itn.storage_account_audit_st_itn.naming_convention": {
-    "hash": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
-    "version": "0.0.5",
+  "storage_itn.storage_account_fims_itn": {
+    "hash": "a2a257b25753f91b36acef29e080efc4d62dea59e803f56e33e813e7a343e66b",
+    "version": "1.0.1",
+    "name": "azure_storage_account",
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/1.0.1"
+  },
+  "weu_resource_group.naming_convention": {
+    "hash": "d7973237e601af346ca3cc8797623f4edff8bdb94b661453d4242609f8d49118",
+    "version": "0.0.7",
     "name": "azure_naming_convention",
-    "source": "https://registry.terraform.io/modules/pagopa/dx-azure-naming-convention/azurerm/0.0.5"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-naming-convention/azurerm/0.0.7"
   }
 }


### PR DESCRIPTION
Bump pagopa-dx/azure-storage-account/azurerm version. 
The old pagopa-dx/azure-storage-account/azurerm  version is importing a **wrong source for the azure-naming-convention module.**